### PR TITLE
Add application/x-kano-make-music MIME information

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -6,6 +6,7 @@ LICENSE_SonicPi /usr/share/sonic-pi
 
 kdesktop/SonicPi.lnk /usr/share/kano-desktop/kdesk/kdesktop/
 kdesktop/make-music.desktop /usr/share/applications/
+kdesktop/sonic-pi.xml /usr/share/mime/packages/
 icon/sonicpi.png /usr/share/kano-desktop/icons/
 icon/sonicpi.png /usr/share/icons/Kano/88x88/apps
 icon/SonicPi-hover.png /usr/share/kano-desktop/icons/

--- a/kdesktop/make-music.desktop
+++ b/kdesktop/make-music.desktop
@@ -2,7 +2,7 @@
 Encoding=UTF-8
 Version=1.0
 Type=Application
-Exec=/usr/bin/kano-launcher /usr/bin/make-music
+Exec=/usr/bin/kano-launcher '/usr/bin/make-music %f'
 Icon=/usr/share/kano-desktop/icons/sonicpi.png
 Terminal=false
 Name=Make Music

--- a/kdesktop/sonic-pi.xml
+++ b/kdesktop/sonic-pi.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+    <mime-type type="application/x-kano-make-music">
+        <comment>Sonic Pi Script</comment>
+        <glob pattern="*.spi"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
KanoComputing/peldins#1511
By adding this XML to `/usr/share/mime/packages`, the MIME type
`application/x-kano-make-music` becomes associated with the `.spi` file
extension. This allows all files with the extension to be launched, by
clicking them, in Sonic Pi. It also allows setting of the icon to be a
custom Sonic Pi one by creating the icon file in the icon theme (as
`mimetypes/application-x-kano-make-music.png`).