### PR TITLE
Shortcuts: Implement (more) sane keyboard shortcuts

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1395,6 +1395,7 @@ void MainWindow::createToolBar()
   setupAction(runAct, 'R', tr("Run the code in the current workspace"),
 	      SLOT(runCode()));
   new QShortcut(Qt::Key_Launch9, this, SLOT(runCode())); // 0x10000AB on the Kano Keyboard
+  new QShortcut(ctrlKey('r'), this, SLOT(runCode())); // ctrl + r
 
   // Stop
   QAction *stopAct = new QAction(QIcon(":/images/stop.png"), tr("Stop"), this);
@@ -1404,6 +1405,7 @@ void MainWindow::createToolBar()
   QAction *saveAsAct = new QAction(QIcon(":/images/save.png"), tr("Save As..."), this);
   setupAction(saveAsAct, 0, tr("Save current workspace as an external file"), SLOT(saveDialog()));
   new QShortcut(Qt::Key_Tools, this, SLOT(saveDialog())); // 0x10000F1 on the Kano Keyboard
+  new QShortcut(ctrlKey('s'), this, SLOT(saveDialog())); // ctrl + s
 
   // Share
   QAction *shareAct = new QAction(QIcon(":/images/share.png"), tr("&Share..."), this);
@@ -1411,14 +1413,15 @@ void MainWindow::createToolBar()
   shareAct->setStatusTip(tr("Share your creation with the world"));
   connect(shareAct, SIGNAL(triggered()), this, SLOT(shareDialog()));
   new QShortcut(Qt::Key_Launch8, this, SLOT(shareDialog())); // 0x10000AA on the Kano Keyboard
+  new QShortcut(ctrlKey('u'), this, SLOT(shareDialog())); // ctrl + u
 
   // Load
   QAction *loadAct = new QAction(QIcon(":/images/load.png"), tr("&Load..."), this);
-  loadAct->setShortcut(tr("ctrl+O"));
   loadAct->setToolTip(tr("Load a workspace"));
   loadAct->setStatusTip(tr("Load a workspace"));
   connect(loadAct, SIGNAL(triggered()), this, SLOT(load()));
   new QShortcut(Qt::Key_Launch7, this, SLOT(load())); // 0x10000A9 on the Kano Keyboard
+  new QShortcut(ctrlKey('o'), this, SLOT(load())); // ctrl + o
 
   // Info
   QAction *infoAct = new QAction(QIcon(":/images/info.png"), tr("Info"), this);


### PR DESCRIPTION
KanoComputing/peldins#1419
In the Kano kit, `xbindkeys` absorbs all of the special keys which are
being listened for by Sonic Pi (for Save, Share, Load and Make) so
instead offer more sane keyboard shortcuts (although some preferences
are already taken so some are a bit strange) to be re-triggered by the
`xbindkeys` script.