### PR TITLE
Sample: Switch sample to be Ogg Vorbis

### DIFF
--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -117,7 +117,7 @@ RESOURCES += \
 RC_FILE = SonicPi.rc
 
 ICON = images/app.icns
-LIBS         += -lqscintilla2 -lmp3lame
+LIBS         += -lqscintilla2 -lmp3lame `pkg-config --libs sndfile`
 
 win32 {
 	install_qsci.files = $$[QT_INSTALL_LIBS]\qscintilla2.dll

--- a/app/gui/qt/SonicPi.pro
+++ b/app/gui/qt/SonicPi.pro
@@ -117,7 +117,7 @@ RESOURCES += \
 RC_FILE = SonicPi.rc
 
 ICON = images/app.icns
-LIBS         += -lqscintilla2 -lmp3lame `pkg-config --libs sndfile`
+LIBS         += -lqscintilla2 `pkg-config --libs sndfile`
 
 win32 {
 	install_qsci.files = $$[QT_INSTALL_LIBS]\qscintilla2.dll

--- a/app/gui/qt/audio_tools.cpp
+++ b/app/gui/qt/audio_tools.cpp
@@ -1,7 +1,6 @@
 #include <string>
 #include <cstring>
 
-#include <lame/lame.h>
 #include <sndfile.h>
 
 #include "audio_tools.h"
@@ -89,59 +88,6 @@ int AudioTools::convert_wav_to_ogg(std::string src_path, std::string dst_path)
 
     sf_close(src_file);
     sf_close(dst_file);
-
-    return 0;
-}
-
-
-int AudioTools::convert_wav_to_mp3(std::string src_path, std::string dst_path) {
-    /**
-     * Convert a wav file to mp3 using the Lame library
-     */
-
-    FILE * src = fopen(src_path.c_str(), "rb");
-
-    if (!src)
-        return -1;
-
-    FILE * dst = fopen(dst_path.c_str(), "wb");
-
-    const int PCM_SIZE = 8192;
-    const int MP3_SIZE = 8192;
-
-    short int pcm_buffer[PCM_SIZE * 2];
-    unsigned char mp3_buffer[MP3_SIZE];
-
-    // Lame config
-    lame_t lame = lame_init();
-
-    lame_set_in_samplerate(lame, 44100);
-    lame_set_VBR(lame, vbr_default);
-    lame_set_num_channels(lame, 2);
-
-    lame_init_params(lame);
-
-    int read, write;
-
-    // Convert
-    do {
-        read = fread(pcm_buffer, 2 * sizeof(short int),
-                     PCM_SIZE, src);
-
-        if (read == 0)
-            write = lame_encode_flush(lame, mp3_buffer, MP3_SIZE);
-        else
-            write = lame_encode_buffer_interleaved(lame, pcm_buffer, read,
-                                                   mp3_buffer, MP3_SIZE);
-
-        fwrite(mp3_buffer, write, 1, dst);
-    } while (read != 0);
-
-    // Clean up
-    lame_close(lame);
-
-    fclose(src);
-    fclose(dst);
 
     return 0;
 }

--- a/app/gui/qt/audio_tools.cpp
+++ b/app/gui/qt/audio_tools.cpp
@@ -1,8 +1,97 @@
 #include <string>
+#include <cstring>
 
 #include <lame/lame.h>
+#include <sndfile.h>
 
 #include "audio_tools.h"
+
+#define BUFFER_LEN    4096
+
+
+int AudioTools::convert_wav_to_ogg(std::string src_path, std::string dst_path)
+{
+    /**
+     * Convert a wav file to ogg/vorbis using the libsndfile Library
+     */
+
+    SF_INFO sf_info;
+    std::memset(&sf_info, 0, sizeof(sf_info));
+
+    SNDFILE * src_file = sf_open(src_path.c_str(), SFM_READ, &sf_info);
+
+    if (!src_file)
+        return -1;
+
+
+    /**
+     * Set the new params
+     */
+
+    sf_info.format = SF_FORMAT_OGG | SF_FORMAT_VORBIS;
+
+    if (sf_format_check(&sf_info) == 0)
+        return -4;
+
+
+    /**
+     * Open the output file
+     */
+
+    SNDFILE * dst_file = sf_open(dst_path.c_str(), SFM_WRITE, &sf_info);
+
+    if (!dst_file)
+        return -2;
+
+
+    /**
+     * Copy metadata
+     */
+
+    const char * metadata_string;
+
+    for (int metadata_key = SF_STR_FIRST; metadata_key <= SF_STR_LAST; metadata_key++) {
+        metadata_string = sf_get_string(src_file, metadata_key);
+
+        if (metadata_string)
+            sf_set_string(dst_file, metadata_key, metadata_string);
+    }
+
+    sf_set_string(dst_file, SF_STR_SOFTWARE, "Sonic Pi on Kano");
+
+
+    /**
+     * Write file
+     */
+
+    // Get the maximum signal for normalisation
+    static double max;
+    sf_command(src_file, SFC_CALC_SIGNAL_MAX, &max, sizeof(max));
+
+    // Turn off normalisation for read values
+    sf_command(src_file, SFC_SET_NORM_DOUBLE, NULL, SF_FALSE);
+
+    // NB: 'frames' are synonymous with 'samples'
+    const int max_buffer_frames = BUFFER_LEN / sf_info.channels;
+    int read_frame_count = max_buffer_frames;
+    double data[BUFFER_LEN];
+
+    while (read_frame_count > 0) {
+        read_frame_count = sf_readf_double(src_file, data, max_buffer_frames);
+
+        // Normalise
+        for (int k = 0; k < read_frame_count * sf_info.channels; k++) {
+            data[k] /= max;
+        }
+
+        sf_writef_double(dst_file, data, read_frame_count);
+    }
+
+    sf_close(src_file);
+    sf_close(dst_file);
+
+    return 0;
+}
 
 
 int AudioTools::convert_wav_to_mp3(std::string src_path, std::string dst_path) {

--- a/app/gui/qt/audio_tools.h
+++ b/app/gui/qt/audio_tools.h
@@ -1,6 +1,5 @@
 #include <string>
 
 namespace AudioTools {
-    int convert_wav_to_mp3(std::string src_path, std::string dst_path);
     int convert_wav_to_ogg(std::string src_path, std::string dst_path);
 }

--- a/app/gui/qt/audio_tools.h
+++ b/app/gui/qt/audio_tools.h
@@ -2,4 +2,5 @@
 
 namespace AudioTools {
     int convert_wav_to_mp3(std::string src_path, std::string dst_path);
+    int convert_wav_to_ogg(std::string src_path, std::string dst_path);
 }

--- a/app/gui/qt/export_dialog.cpp
+++ b/app/gui/qt/export_dialog.cpp
@@ -56,8 +56,8 @@ int ExportDialog::save() {
 
     save_to_file(filepath + std::string(".spi"), file_contents);
     save_to_file(filepath + std::string(".json"), json_data);
-    AudioTools::convert_wav_to_mp3(SAMPLE_TMP_PATH,
-                                   filepath + std::string(".mp3"));
+    AudioTools::convert_wav_to_ogg(SAMPLE_TMP_PATH,
+                                   filepath + std::string(".ogg"));
 
 	return 0;
 }

--- a/debian/control
+++ b/debian/control
@@ -4,13 +4,12 @@ Section: sound
 Priority: optional
 Standards-Version: 3.9.4
 Build-Depends: debhelper (>=9.0.0), qt4-dev-tools, libqt4-dev, libqscintilla2-dev,
- ruby (>=1.9.3), ruby-dev, make, cmake, libmp3lame-dev, libsndfile1-dev,
- pkg-config
+ ruby (>=1.9.3), ruby-dev, make, cmake, libsndfile1-dev, pkg-config
 
 Package: make-music
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, libc6, supercollider, jackd2,
  ruby (>=1.9.3), libqscintilla2-8, libqtgui4, libqt4-network, libqtdbus4,
- kano-toolset (>= 1.2-2), libmp3lame0, kano-profile (>=2.1-1), libsndfile1
+ kano-toolset (>= 1.2-2), kano-profile (>=2.1-1), libsndfile1
 Description: Make Music with a music programming environment
  A programatic approach to making music based on Sam Aaron's Sonic Pi

--- a/debian/control
+++ b/debian/control
@@ -4,12 +4,13 @@ Section: sound
 Priority: optional
 Standards-Version: 3.9.4
 Build-Depends: debhelper (>=9.0.0), qt4-dev-tools, libqt4-dev, libqscintilla2-dev,
- ruby (>=1.9.3), ruby-dev, make, cmake, libmp3lame-dev
+ ruby (>=1.9.3), ruby-dev, make, cmake, libmp3lame-dev, libsndfile1-dev,
+ pkg-config
 
 Package: make-music
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, libc6, supercollider, jackd2,
  ruby (>=1.9.3), libqscintilla2-8, libqtgui4, libqt4-network, libqtdbus4,
- kano-toolset (>= 1.2-2), libmp3lame0, kano-profile (>=2.1-1)
+ kano-toolset (>= 1.2-2), libmp3lame0, kano-profile (>=2.1-1), libsndfile1
 Description: Make Music with a music programming environment
  A programatic approach to making music based on Sam Aaron's Sonic Pi


### PR DESCRIPTION
Supersedes KanoComputing/sonic-pi/pull/38
 
KanoComputing/peldins#1691
The sample used to be encoded as MP3 but there are licensing concerns
with this so switch to use an open format.

Ensure that all of the offending MP3 code is removed and all
dependencies on non-free MP3 library packages is removed.

@convolu Makes some progress towards:
KanoComputing/peldins#1858

@pazdera @skarbat @Ealdwulf Could you please review?