### PR TITLE
Volume: Remove setting RPi audio

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1515,15 +1515,10 @@ void MainWindow::changeRPSystemVol(int)
   // do nothing
 #else
   //assuming Raspberry Pi
-  QProcess *p = new QProcess();
-  float v = (float) val;
-  // handle the fact that the amixer percentage range isn't linear
-  float vol_float = std::pow(v/100.0, (float)1./3.) * 100.0;
-  std::ostringstream ss;
-  ss << vol_float;
-  statusBar()->showMessage(tr("Updating System Volume..."), 2000);
-  QString prog = "amixer cset numid=1 " + QString::fromStdString(ss.str()) + '%';
-  p->start(prog);
+
+  /**
+   * Do nothing for now - maybe implement properly later.
+   */
 #endif
 
 }


### PR DESCRIPTION
KanoComputing/peldins#2172
Sonic Pi overrides any audio settings that we may have otherwise set in
the system and thus plays at its own volume. This can be troublesome if
the user has sensory issues which they expect the master audio to be
able to solve so remove the ability for Sonic Pi to change the setting
for now.

cc @radujipa 