### PR TITLE
Workspace: Decrease default size

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -2205,8 +2205,8 @@ void MainWindow::readSettings() {
     tabs->setCurrentIndex(index);
 
   for (int w=0; w < workspace_max; w++) {
-    // default zoom is 13
-    int zoom = settings.value(QString("workspace%1zoom").arg(w), 13)
+    // default zoom is 0
+    int zoom = settings.value(QString("workspace%1zoom").arg(w), 0)
       .toInt();
     if (zoom < -5) zoom = -5;
     if (zoom > 20) zoom = 20;

--- a/debian/postinst
+++ b/debian/postinst
@@ -13,6 +13,12 @@ case "$1" in
         # Create Symlink
         ln -s /usr/share/sonic-pi/app/gui/qt/sonic-pi /usr/bin/make-music
 
+        if `dpkg --compare-versions $2 lt 2.9-0`; then
+            # v2.9-0: New defaults for workspace size so remove old ones
+            find /home -path /home/*/.config/uk.ac.cam.cl/Sonic\ Pi.conf \
+                -exec sed -ri '/^workspace[[:digit:]]+zoom=[[:digit:]]+$/d' {} \;
+        fi
+
         ;;
 esac
 


### PR DESCRIPTION
KanoComputing/peldins#2215
The default workspace had zooming applied. Remove this and reset any
installs affected by this.