### PR TITLE
Implement an additional slot to load shares

### DIFF
--- a/app/gui/qt/dbus_actions.cpp
+++ b/app/gui/qt/dbus_actions.cpp
@@ -32,6 +32,12 @@ void DbusActionsAdaptor::load()
     QMetaObject::invokeMethod(parent(), "load");
 }
 
+void DbusActionsAdaptor::launch_share(const QString share_filename)
+{
+    // handle method call me.kano.sonicpi.load_share, passing the filename to load into workspace.
+    QMetaObject::invokeMethod(parent(), "load_share", Qt::AutoConnection, Q_ARG(QString, share_filename));
+}
+
 void DbusActionsAdaptor::make()
 {
     // handle method call me.kano.sonicpi.make

--- a/app/gui/qt/dbus_actions.h
+++ b/app/gui/qt/dbus_actions.h
@@ -34,6 +34,8 @@ class DbusActionsAdaptor: public QDBusAbstractAdaptor
 "    <method name=\"save\"/>\n"
 "    <method name=\"share\"/>\n"
 "    <method name=\"load\"/>\n"
+"    <method name=\"launch_share\"/>\n"
+"      <arg direction=\"in\" type=\"s\"/>\n"
 "    <method name=\"make\"/>\n"
 "  </interface>\n"
         "")
@@ -44,6 +46,7 @@ public:
 public: // PROPERTIES
 public Q_SLOTS: // METHODS
     void load();
+    void launch_share(const QString share_filename);
     void make();
     void save();
     void share();

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1262,6 +1262,13 @@ void MainWindow::load()
     delete load_from_dialog;
 }
 
+
+void MainWindow::launch_share(const QString share_filename)
+{
+    // Loads "share_filename" directly into the workspace
+    getCurrentWorkspace()->setText(share_filename);
+}
+
 void MainWindow::sendOSC(Message m)
 {
   int TIMEOUT = 30000;

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -121,6 +121,7 @@ private slots:
     bool saveDialog();
     bool shareDialog();
     void load();
+    void launch_share(const QString share_filename);
     void about();
     void help();
     void onExitCleanup();


### PR DESCRIPTION
 * A new entry point "load_share" is connected to DBus, which accepts the name of a share to load into the workspace.

What do you guys think about this one? It is to be able to load music creations from KW.
I am a bit surprised that `setText()` will unfold everything up, but that's apparently how `load` does it.

@tombettany @convolu 
