### PR TITLE
Load share signal

### DIFF
--- a/app/gui/qt/dbus_actions.cpp
+++ b/app/gui/qt/dbus_actions.cpp
@@ -32,6 +32,12 @@ void DbusActionsAdaptor::load()
     QMetaObject::invokeMethod(parent(), "load");
 }
 
+void DbusActionsAdaptor::load_share(const QString share_filename)
+{
+    // handle method call me.kano.sonicpi.load_share
+    QMetaObject::invokeMethod(parent(), "load_share", Qt::AutoConnection, Q_ARG(QString, share_filename));
+}
+
 void DbusActionsAdaptor::make()
 {
     // handle method call me.kano.sonicpi.make

--- a/app/gui/qt/dbus_actions.h
+++ b/app/gui/qt/dbus_actions.h
@@ -34,6 +34,9 @@ class DbusActionsAdaptor: public QDBusAbstractAdaptor
 "    <method name=\"save\"/>\n"
 "    <method name=\"share\"/>\n"
 "    <method name=\"load\"/>\n"
+"    <method name=\"load_share\">\n"
+"      <arg direction=\"in\" type=\"s\"/>\n"
+"    </method>"
 "    <method name=\"make\"/>\n"
 "  </interface>\n"
         "")
@@ -44,6 +47,7 @@ public:
 public: // PROPERTIES
 public Q_SLOTS: // METHODS
     void load();
+    void load_share(const QString share_filename);
     void make();
     void save();
     void share();

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1262,10 +1262,36 @@ void MainWindow::load()
     delete load_from_dialog;
 }
 
+
+/*
+ *   load_share(share_filename)
+ *
+ *   This function loads a filename containing the code for a SonicPi project
+ *   and unfolds it into the current workspace.
+ *
+ */
 void MainWindow::load_share(const QString share_filename)
 {
-    // TODO: unfold the file into the workspace.
-    getCurrentWorkspace()->setText(share_filename);
+    QFile sharedCreation(share_filename);
+
+    if (!sharedCreation.exists() || !sharedCreation.open(QIODevice::ReadOnly | QIODevice::Text)) {
+      QMessageBox load_failed;
+      load_failed.setText(QString(tr("The Shared creation file could not be loaded: %1").arg(share_filename)));
+      load_failed.exec();
+    }
+    else {
+      // Ask confirmation before removing the current creation
+      QMessageBox::StandardButton reply;
+      reply = QMessageBox::question(this, tr("Loading a share"),
+				    tr("Are you sure you want to load this share? You will loose the current workspace"),
+				    QMessageBox::Yes|QMessageBox::No);
+
+      if (reply == QMessageBox::Yes) {
+	QTextStream shared_code(&sharedCreation);
+	getCurrentWorkspace()->setText(sharedCreation.readAll());
+	sharedCreation.close();
+      }
+    }
 }
 
 void MainWindow::sendOSC(Message m)

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1262,6 +1262,12 @@ void MainWindow::load()
     delete load_from_dialog;
 }
 
+void MainWindow::load_share(const QString share_filename)
+{
+    // TODO: unfold the file into the workspace.
+    getCurrentWorkspace()->setText(share_filename);
+}
+
 void MainWindow::sendOSC(Message m)
 {
   int TIMEOUT = 30000;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1283,14 +1283,14 @@ void MainWindow::load_share(const QString share_filename)
       // Ask confirmation before removing the current creation
       QMessageBox::StandardButton reply;
       reply = QMessageBox::question(this, tr("Loading a share"),
-				    tr("Are you sure you want to load this share? You will loose the current workspace"),
+				    tr("Are you sure you want to load this share? You will lose the current workspace"),
 				    QMessageBox::Yes|QMessageBox::No);
 
       if (reply == QMessageBox::Yes) {
 	QTextStream shared_code(&sharedCreation);
 	getCurrentWorkspace()->setText(sharedCreation.readAll());
-	sharedCreation.close();
       }
+      sharedCreation.close();
     }
 }
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -121,6 +121,7 @@ private slots:
     bool saveDialog();
     bool shareDialog();
     void load();
+    void load_share(const QString share_filename);
     void about();
     void help();
     void onExitCleanup();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-make-music (2.10-0) unstable; urgency=low
-
-  * Added functionality to load a Kano World shared creation
-
- -- Team Kano <dev@kano.me>  Mon, 28 Jan 2016 20:22:00 +0100
-
 make-music (2.9-0) unstable; urgency=low
 
   * Updated version to Sonic-Pi 2.9.0 (Venster)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+make-music (2.9-0) unstable; urgency=low
+
+  * Updated version to Sonic-Pi 2.9.0 (Venster)
+
+ -- Team Kano <dev@kano.me>  Mon, 18 Jan 2016 15:15:00 +0000
+
 make-music (2.7-0) unstable; urgency=low
 
   * Updated version to Sonic-Pi 2.7.0 (Rerezzed)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+make-music (2.10-0) unstable; urgency=low
+
+  * Added functionality to load a Kano World shared creation
+
+ -- Team Kano <dev@kano.me>  Mon, 28 Jan 2016 20:22:00 +0100
+
 make-music (2.9-0) unstable; urgency=low
 
   * Updated version to Sonic-Pi 2.9.0 (Venster)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Team Kano <dev@kano.me>
 Section: sound
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0), qt4-dev-tools, libqt4-dev, libqscintilla2-dev,
+Build-Depends: debhelper (>=9.0.0), qt4-dev-tools, libqt4-dev, libffi-dev, libqscintilla2-dev,
  ruby (>=1.9.3), ruby-dev, make, cmake, libsndfile1-dev, pkg-config
 
 Package: make-music

--- a/debian/rules
+++ b/debian/rules
@@ -4,5 +4,5 @@
 	dh $@
 
 override_dh_auto_build:
-	app/gui/qt/rp-build-app
 	app/server/bin/compile-extensions.rb
+	app/gui/qt/rp-build-app


### PR DESCRIPTION
@tombettany this PR replaces this one: https://github.com/KanoComputing/sonic-pi/pull/44

I need to finish the unfolding of the shared filename into the workspace.
right now only the string is put into it.

cc @Ealdwulf 
 