### PR TITLE
Fixing postinst when we are installing for the first time

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -13,10 +13,15 @@ case "$1" in
         # Create Symlink
         ln -s /usr/share/sonic-pi/app/gui/qt/sonic-pi /usr/bin/make-music
 
-        if `dpkg --compare-versions $2 lt 2.9-0`; then
-            # v2.9-0: New defaults for workspace size so remove old ones
-            find /home -path /home/*/.config/uk.ac.cam.cl/Sonic\ Pi.conf \
+        # From Debian docs: "postinst configure most-recently-configured-version"
+        # If there is no most recently configured version dpkg will pass a null argument
+        if [ "$2" != "" ]; then
+            # If we are configuring from a previous version, remove the old workspace defaults
+            if `dpkg --compare-versions $2 lt 2.9-0`; then
+                # v2.9-0: New defaults for workspace size so remove old ones
+                find /home -path /home/*/.config/uk.ac.cam.cl/Sonic\ Pi.conf \
                 -exec sed -ri '/^workspace[[:digit:]]+zoom=[[:digit:]]+$/d' {} \;
+            fi
         fi
 
         ;;


### PR DESCRIPTION
I think this should fix the complaints we get during the initial install, @tombettany @convolu .

```
Setting up make-music (2.9-0.20160201) ...
dpkg: error: --compare-versions takes three arguments: <version> <relation> <version>
```

I have also added a test: https://github.com/KanoComputing/QA/commit/92f0b1207bf24e6299e0f1e228d4fba2c98db89b
