### PR TITLE
Debian: Bump version to 2.10-0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+make-music (2.10-0) unstable; urgency=low
+
+  * Updated version to Sonic-Pi 2.10.0 (Cowbell)
+
+ -- Team Kano <dev@kano.me>  Tue, 07 Jun 2016 14:00:00 +0000
+
 make-music (2.9-0) unstable; urgency=low
 
   * Updated version to Sonic-Pi 2.9.0 (Venster)


### PR DESCRIPTION
KanoComputing/peldins#2394
Sonic Pi's version was updated to v2.10.0 so bump the Debian package
version to match.