### PR TITLE
Challenges: Load challenges into workspaces

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1451,6 +1451,7 @@ void MainWindow::load()
     int rc = load_from_dialog->exec();
 
     if (rc == QDialog::Accepted) {
+        this->changeTab(this->workspace_max - 1);
         getCurrentWorkspace()->setText(QString::fromStdString(load_from_dialog->get_file_contents()));
     }
 

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -894,7 +894,6 @@ void MainWindow::splashClose() {
 
 void MainWindow::showWindow() {
   splashClose();
-  loadWorkspaces();
 
   if (!this->file_to_load.empty())
     this->load_share(QString::fromStdString(this->file_to_load), true);
@@ -1350,6 +1349,9 @@ void MainWindow::loadWorkspaces()
   std::cout << "[GUI] - loading workspaces" << std::endl;
 
   for(int i = 0; i < workspace_max; i++) {
+    if (i == workspace_max - 1 && !this->file_to_load.empty())
+        continue;
+
     Message msg("/load-buffer");
     msg.pushStr(guiID.toStdString());
     std::string s = "workspace_" + number_name(i);
@@ -1496,7 +1498,8 @@ void MainWindow::load_share(const QString share_filename, const bool force)
     if (force || reply == QMessageBox::Yes) {
         this->changeTab(this->workspace_max - 1);
         QTextStream shared_code(&shared_creation);
-        this->getCurrentWorkspace()->setText(shared_creation.readAll());
+        QString code = shared_code.readAll();
+        this->getCurrentWorkspace()->setText(code);
     }
 
     shared_creation.close();

--- a/app/server/sonicpi/lib/sonicpi/runtime.rb
+++ b/app/server/sonicpi/lib/sonicpi/runtime.rb
@@ -415,13 +415,20 @@ module SonicPi
     def __load_buffer(id)
       id = id.to_s
       raise "Aborting load: file name is blank" if  id.empty?
+
+      challenge = "#{challenge_path}/#{id}.spi"
       path = project_path + id + '.spi'
+
       s = "# Welcome to Sonic Pi #{@version.to_s}\n\n"
+
       if File.exists? path
         s = IO.read(path)
       elsif File.exists? id
         s = IO.read(id)
+      elsif File.exists? challenge
+        s = IO.read(challenge)
       end
+
       __replace_buffer(id, s)
     end
 

--- a/app/server/sonicpi/lib/sonicpi/util.rb
+++ b/app/server/sonicpi/lib/sonicpi/util.rb
@@ -149,22 +149,10 @@ module SonicPi
 
     def project_path
       return @@project_path if @@project_path
-      @@util_lock.synchronize do
-        return @@project_path if @@project_path
-        ## TODO: allow user to modify this for different projects
-        path = home_dir + '/store/default/'
-        ensure_dir(path)
-        ensure_challenges(path)
-        @@project_path = path
-        path
-      end
     end
 
-    def ensure_challenges(project_path)
-      challenge_path = File.absolute_path("#{root_path}/challenges")
-      Dir["#{challenge_path}/*.spi"].each do |challenge|
-        FileUtils.cp_r challenge, project_path
-      end
+    def challenge_path
+        return File.absolute_path("#{root_path}/challenges")
     end
 
     def log_path


### PR DESCRIPTION
KanoComputing/os-dashboard#2392
Add back the loading of challenges into the workspaces at startup.

Also fix up some other things to do with loading workspaces.