### PR TITLE
Repurposed ShareDialog into launcher for kano-share-gui

### DIFF
--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1434,7 +1434,11 @@ bool MainWindow::shareDialog()
     ShareDialog * share_dialog = new ShareDialog(this);
     share_dialog->set_file_contents(getCurrentWorkspace()->text().toUtf8().constData());
 
-    share_dialog->exec();
+    // Share using kano-share-gui tool.
+    share_dialog->open_external_dialog();
+
+    // Do not call this function anymore.
+    // share_dialog->exec();
 
     delete share_dialog;
 

--- a/app/gui/qt/share_dialog.h
+++ b/app/gui/qt/share_dialog.h
@@ -14,11 +14,16 @@ class ShareDialog : public ExportDialog
 				initialise();
             };
 
+        int open_external_dialog();
+
     protected slots:
 	    int export_file();
 
 	protected:
 		void initialise();
+
+    private:
+        QString getFormatedDate() const;
 };
 
 #endif

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Package: make-music
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, libc6, supercollider, jackd2,
  ruby (>=1.9.3), libqscintilla2-11, libqtgui4, libqt4-network, libqtdbus4,
- kano-toolset (>= 1.2-2), kano-profile (>=2.1-1), libsndfile1
+ kano-toolset (>= 1.2-2), kano-profile (>=2.1-1), libsndfile1, kano-share-gui
 Description: Make Music with a music programming environment
  A programatic approach to making music based on Sam Aaron's Sonic Pi


### PR DESCRIPTION
Related to https://trello.com/c/zqYL354D/38-integrate-unified-sharing-flow-on-all-apps

@tombettany @skarbat 

A few notes:
 - The ShareDialog is essentially only used to perform a `save()` and then pop-up kano-share-gui. It is not executed as a Qt dialog anymore.
 - What needs to happen is a refactor of the entire inheritance tree of death of the IODialog -> ExportDialog -> SaveDialog / ShareDialog to use a SaveManager which would take care of the functionality that is currently inside UI components.
 - Also, because the app no longer is responsible from grabbing the share title, the file names have been changed to a timestamp.
 - Yes, the approach isn't brilliant. I don't like it either. Depending on the time constrains we may or may not get the do the above. That being said, I'm not in favour of the solution below.

**P.S.** The only way I was able to build this is on the Pi, which takes roughly 20mins.