### PR TITLE
Renamed sonic-pi to make-music as the share apt-title

### DIFF
--- a/app/gui/qt/share_dialog.cpp
+++ b/app/gui/qt/share_dialog.cpp
@@ -39,7 +39,7 @@ int ShareDialog::open_external_dialog() {
     std::string filepath = save_dir + filename + std::string(".spi");
 
     std::string cmd = std::string("/usr/bin/kano-share-container ") + filepath
-                    + std::string(" --app-title sonic-pi");
+                    + std::string(" --app-title make-music");
     if (!(share_proc = popen(cmd.c_str(), "r"))) {
         this->setCursor(QCursor(Qt::ArrowCursor));
         return -1;


### PR DESCRIPTION
@tombettany 

The sharing flow does not recognise `sonic-pi` as the app title, `make-music` is the one it's looking for.