### PR TITLE
Icon: Remove %f in launch command

### DIFF
--- a/icon/make-music.app
+++ b/icon/make-music.app
@@ -12,7 +12,7 @@
 
     "packages": [],
     "dependencies": ["make-music"],
-    "launch_command": "kano-tracker-ctl session run make-music \"/usr/bin/kano-launcher 'make-music %f'\"",
+    "launch_command": "kano-tracker-ctl session run make-music \"/usr/bin/kano-launcher 'make-music'\"",
     "overrides": [],
     "desktop": false
 }


### PR DESCRIPTION
The '%f' appended to the launch command in the `.app` file is not
interpreted correctly by the dashboard. It is utilised by pcmanfm to
launch Sonic Pi with a file but with the transition away from classic
mode towards the dashboard, fixing it in the dashboard is preferable.
The solution here is to simply remove the string.

@Ealdwulf to review.

cc @radujipa @jonasskjoldan 