### PR TITLE
i18n: Set priority for es_AR `.app` file

### DIFF
--- a/icon/locale/es_AR/make-music.app
+++ b/icon/locale/es_AR/make-music.app
@@ -1,20 +1,6 @@
 {
-    "launch_command": "kano-tracker-ctl session run make-music \"/usr/bin/kano-launcher 'make-music'\"", 
-    "description": "Controlas algunos instrumentos con teclas y otros con tambores. Pero una computadora puede hacer cualquier sonido imaginable. Y t\u00fa puedes controlar estos sonidos con c\u00f3digo. Con Sonic Pi, puedes escribir c\u00f3digo para crear melod\u00edas, ritmos, canciones y sinfon\u00edas. Escribiendo instrucciones en un lenguaje especial, aprender\u00e1s a utilizar la programaci\u00f3n para sacar el m\u00e1ximo partido de tu Kano.", 
-    "title": "Sonic Pi", 
-    "tagline": "Haz m\u00fasica con c\u00f3digo", 
-    "colour": "#5e96b3", 
-    "desktop": false, 
-    "dependencies": [
-        "make-music"
-    ], 
-    "mime_type": "application/x-kano-make-music", 
-    "overrides": [], 
-    "packages": [], 
-    "slug": "make-music", 
-    "categories": [
-        "code"
-    ], 
-    "icon": "sonicpi",
-    "priority": 50
+    "title": "Sonic Pi",
+    "description": "Controlas algunos instrumentos con teclas y otros con tambores. Pero una computadora puede hacer cualquier sonido imaginable. Y t\u00fa puedes controlar estos sonidos con c\u00f3digo. Con Sonic Pi, puedes escribir c\u00f3digo para crear melod\u00edas, ritmos, canciones y sinfon\u00edas. Escribiendo instrucciones en un lenguaje especial, aprender\u00e1s a utilizar la programaci\u00f3n para sacar el m\u00e1ximo partido de tu Kano.",
+    "tagline": "Haz m\u00fasica con c\u00f3digo",
+    "priority": 750
 }


### PR DESCRIPTION
Set the priority field for the `es_AR` `.app` icon and remove entries
duplicated in the English version.

Per https://docs.google.com/spreadsheets/d/1t6uLVB0FAv04rW9gHtP3wnNYWgq-DcwNS74zEyN5fHE/edit?ts=58a48f50#gid=0

cc @radujipa @skarbat 