### PR TITLE
Challenges: Fix missing comment on challenge two

### DIFF
--- a/challenges/es_AR/workspace_one.spi
+++ b/challenges/es_AR/workspace_one.spi
@@ -3,8 +3,8 @@
 # ¡Empieza a escribir tu propia música!
 #------------------------------------------------------#
 
-Necesitamos DOS ingredientes para hacer música.
-Primero necesitamos el TONO. Esto nos dice qué tan aguda o grave es una nota.
+# Necesitamos DOS ingredientes para hacer música.
+# Primero necesitamos el TONO. Esto nos dice qué tan aguda o grave es una nota.
 
 # 1. Escribe esto abajo: play 80
 


### PR DESCRIPTION
The missing comment symbol caused the challenge to throw an error when
run as the comment text was executed. Resolve this by ensuring that they
are commented out.