### PR TITLE
Fixed es_AR challenges rendering of UTF-8 characters

### DIFF
--- a/app/gui/qt/load_source_dialog.cpp
+++ b/app/gui/qt/load_source_dialog.cpp
@@ -1,6 +1,10 @@
 #include <QFileDialog>
+#include <QFile>
+#include <QTextStream>
+#include <QIODevice>
 #include <fstream>
 #include <iostream>
+#include <QDebug>
 
 #include "load_source_dialog.h"
 
@@ -33,11 +37,19 @@ void LoadSourceDialog::connect_listeners() {
 int LoadSourceDialog::read_file(std::string filename) {
     file_contents = "";
 
-    std::ifstream file(filename.c_str());
-    char buff;
+    QFile file(QString::fromStdString(filename));
 
-    while (file.get(buff)) {
-        file_contents += buff;
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return -1;
+    }
+
+    QTextStream stream(&file);
+    stream.setCodec("UTF-8");
+
+    while (!stream.atEnd()) {
+        QString line = stream.readLine();
+        file_contents += line.toStdString();
+        file_contents += '\n';
     }
 
     file.close();
@@ -60,7 +72,7 @@ int LoadSourceDialog::load_from_local() {
         return -1;
     }
 
-    read_file(filename.toUtf8().constData());
+    read_file(filename.toStdString());
 
     this->accept();
     return 0;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1505,6 +1505,7 @@ void MainWindow::load_share(const QString share_filename, const bool force)
     if (force || reply == QMessageBox::Yes) {
         this->changeTab(this->workspace_max - 1);
         QTextStream shared_code(&shared_creation);
+        shared_code.setCodec("UTF-8");
         QString code = shared_code.readAll();
         this->getCurrentWorkspace()->setText(code);
     }
@@ -2550,6 +2551,7 @@ void MainWindow::loadFile(const QString &fileName, SonicPiScintilla* &text)
   }
 
   QTextStream in(&file);
+  in.setCodec("UTF-8");
   QApplication::setOverrideCursor(Qt::WaitCursor);
   text->setText(in.readAll());
   QApplication::restoreOverrideCursor();

--- a/challenges/es_AR/workspace_five.spi
+++ b/challenges/es_AR/workspace_five.spi
@@ -1,16 +1,16 @@
 #------------------------------------------------------#
-# DesafÃ­o 6 : Â¡RepÃ­tela!
-# Haz que repita tu mÃºsica por arte de magia
+# Desafío 6 : ¡Repítela!
+# Haz que repita tu música por arte de magia
 #------------------------------------------------------#
 
-# Hagamos que la computadora repita el cÃ³digo que escribimos antes
+# Hagamos que la computadora repita el código que escribimos antes
 
 # 1. Escribe: 3. times do
 
 
 
-# 2. Copia tu canciÃ³n del desafÃ­o anterior y 
-#    pÃ©gala a continuaciÃ³n
+# 2. Copia tu canción del desafío anterior y
+#    pégala a continuación
 
 
 

--- a/challenges/es_AR/workspace_four.spi
+++ b/challenges/es_AR/workspace_four.spi
@@ -1,23 +1,23 @@
 #------------------------------------------------------#
-# Desaf铆o 5 : Nuevo instrumento
-# 隆Cambia el sonido de tu m煤sica!
+# Desaf韔 5 : Nuevo instrumento
+# ambia el sonido de tu m鷖ica!
 #------------------------------------------------------#
 
-# 隆Agreguemos un nuevo instrumento a la canci贸n que acabas de escribir! 
+# greguemos un nuevo instrumento a la canci髇 que acabas de escribir!
 
 # 1. Escribe: use_synth :saw
 
 
 
-# 2. Copia tu canci贸n del desaf铆o anterior y 
-#    p茅gala a continuaci贸n
+# 2. Copia tu canci髇 del desaf韔 anterior y
+#    p間ala a continuaci髇
 
 
 
 
 
-# 隆with_synth nos permite cambiar el efecto de sonido que usa
-# tu computadora cuando reproduce nuestra canci贸n!
+# ith_synth nos permite cambiar el efecto de sonido que usa
+# tu computadora cuando reproduce nuestra canci髇!
 
 #************************************#
 #     Ahora presiona la tecla RUN    #

--- a/challenges/es_AR/workspace_one.spi
+++ b/challenges/es_AR/workspace_one.spi
@@ -1,10 +1,10 @@
 #------------------------------------------------------#
-# DesafÃ­o 2 : Creador de Notas
-# Â¡Empieza a escribir tu propia mÃºsica!
+# Desafío 2 : Creador de Notas
+# ¡Empieza a escribir tu propia música!
 #------------------------------------------------------#
 
-# Necesitamos DOS ingredientes para hacer mÃºsica.
-# Primero necesitamos el TONO. Esto nos dice quÃ© tan aguda o grave es una nota.
+# Necesitamos DOS ingredientes para hacer música.
+# Primero necesitamos el TONO. Esto nos dice qué tan aguda o grave es una nota.
 
 # 1. Escribe esto abajo: play 80
 
@@ -13,9 +13,9 @@
 
 
 
-# Esto tocarÃ¡ la octogÃ©sima nota en el piano. Â¡Los nÃºmeros menores
-# hacen que el sonido sea mÃ¡s grave y los nÃºmeros mayores hacen que sea mÃ¡s agudo.
+# Esto tocará la octogésima nota en el piano. ¡Los números menores
+# hacen que el sonido sea más grave y los números mayores hacen que sea más agudo.
 
 #************************************#
-#     Ahora presiona el botÃ³n Run    #
+#     Ahora presiona el botón Run    #
 #************************************#

--- a/challenges/es_AR/workspace_six.spi
+++ b/challenges/es_AR/workspace_six.spi
@@ -1,6 +1,6 @@
 #------------------------------------------------------#
-# DesafÃ­o 7 : Â¡Realmente aleatorio!
-# Haz mÃºsica con nÃºmeros aleatorios
+# Desafío 7 : ¡Realmente aleatorio!
+# Haz música con números aleatorios
 #------------------------------------------------------#
 
 
@@ -20,10 +20,10 @@
 
 
 
-# rrand rrand le dice a la computadora que elija un nÃºmero aleatorio
-# entre los dos nÃºmeros que fijas.
+# rrand rrand le dice a la computadora que elija un número aleatorio
+# entre los dos números que fijas.
 
-# P.ej. rrand(50,100) elegirÃ¡ un nÃºmero entre el 50 y el 100.
+# P.ej. rrand(50,100) elegirá un número entre el 50 y el 100.
 
 
 #************************************#

--- a/challenges/es_AR/workspace_three.spi
+++ b/challenges/es_AR/workspace_three.spi
@@ -1,15 +1,15 @@
 #------------------------------------------------------#
-# DesafÃ­o 4 : Â¡Sigue escribiendo!
-# Usa tus nuevas habilidades para escribir una canciÃ³n.
+# Desafío 4 : ¡Sigue escribiendo!
+# Usa tus nuevas habilidades para escribir una canción.
 #------------------------------------------------------#
 
-# Utiliza play + sleep para componer tu propia canciÃ³n a continuaciÃ³n:
+# Utiliza play + sleep para componer tu propia canción a continuación:
 
 play 80
 sleep 1
 
 
-#Â¡TermÃ­nala tÃº!â€¦
+#¡Termínala tú!?
 
 
 

--- a/challenges/es_AR/workspace_two.spi
+++ b/challenges/es_AR/workspace_two.spi
@@ -1,10 +1,10 @@
 #------------------------------------------------------#
-# DesafÃ­o 3 : Maestro del Tiempo
+# Desafío 3 : Maestro del Tiempo
 # Controla tus notas con el tiempo
 #------------------------------------------------------#
 
-# El segundo ingrediente que necesitamos es DURACIÃ“N. Como lo dice su nombre, esto indica la
-# duraciÃ³n de cada nota.
+# El segundo ingrediente que necesitamos es DURACIÓN. Como lo dice su nombre, esto indica la
+# duración de cada nota.
 
 
 # 1. Escribe: play 80
@@ -17,8 +17,8 @@
 
 
 
-# Esto harÃ¡ sonar la nota durante 1 segundo. Los nÃºmeros menores
-# hacen que la nota dure menos tiempo. Â¿Por quÃ© no experimentas un poco?
+# Esto hará sonar la nota durante 1 segundo. Los números menores
+# hacen que la nota dure menos tiempo. ¿Por qué no experimentas un poco?
 
 
 

--- a/challenges/es_AR/workspace_zero.spi
+++ b/challenges/es_AR/workspace_zero.spi
@@ -1,13 +1,13 @@
 #------------------------------------------------------#
-# DesafÃ­o 1 : Pon algunos ritmos funky
+# Desafío 1 : Pon algunos ritmos funky
 # Empezieza a jugar con Sonic Pi
 #------------------------------------------------------#
 
 # Vamos a hacer algo que probablamente nunca has hecho
-# antes: Â¡vamos a hacer mÃºsica mediante CÃ“DIGO INFORMÃTICO! 
+# antes: ¡vamos a hacer música mediante CÓDIGO INFORMÁTICO!
 
-# AquÃ­ estÃ¡ una canciÃ³n funky pata ayudarte a empezar. 
-# Â¡Haz click en el botÃ³n Run en la parte superior izquierda para escucharla!
+# Aquí está una canción funky pata ayudarte a empezar.
+# ¡Haz click en el botón Run en la parte superior izquierda para escucharla!
 
 play 80
 sleep 1
@@ -18,4 +18,4 @@ sleep 1
 play 71
 sleep 1
 
-# Genial, Â¿verdad? Â¡Escribamos nuestra propia! Abre DesafÃ­o 2.  
+# Genial, ¿verdad? ¡Escribamos nuestra propia! Abre Desafío 2.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+make-music (3.9.2-0) unstable; urgency=low
+
+  * Encoded es_AR challenges to Latin1 due to Sonic Pi bug (backport)
+  * Fixed loading files with UTF-8 characters
+
+ -- Team Kano <dev@kano.me>  Wed, 11 Oct 2017 18:31:00 +0100
+
+make-music (3.9.1-0) unstable; urgency=low
+
+  * Fixed missing comment on es_AR challenge two (backport)
+
+ -- Team Kano <dev@kano.me>  Fri, 21 Jul 2017 13:12:47 +0100
+
 make-music (2.10-0) unstable; urgency=low
 
   * Updated version to Sonic-Pi 2.10.0 (Cowbell)


### PR DESCRIPTION
The issue here is an obscure bug in Sonic Pi due to which the UTF-8
encoded challenges were encoded to UTF-8 again, causing the chars
to not render properly. Due to the obscurity of this, the challenges
themselves were encoded to Latin1; double UTF-8 encoding becomes the
right one... Additionally, the Load mechanism was also updated to be
able to load files which were saved with UTF-8 chars (loading the
challenge files from here creates issues).

**NOTE:** This is the application of https://github.com/KanoComputing/sonic-pi/pull/64 to the next release.