### PR TITLE
Bumped changelog with applied changes from v3.9.2 es_AR backports

### DIFF
--- a/app/gui/qt/load_source_dialog.cpp
+++ b/app/gui/qt/load_source_dialog.cpp
@@ -4,7 +4,6 @@
 #include <QIODevice>
 #include <fstream>
 #include <iostream>
-#include <QDebug>
 
 #include "load_source_dialog.h"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+make-music (3.14.0-0) unstable; urgency=low
+
+  * Applied changes from v3.9.2 es_AR backports to latest
+
+ -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+
 make-music (3.9.2-0) unstable; urgency=low
 
   * Encoded es_AR challenges to Latin1 due to Sonic Pi bug (backport)


### PR DESCRIPTION
This is to specify that the changes made in the es_AR image need to be rebuilt, tested, and released from master as well.