### PR TITLE
Adapted dependency for Debian Stretch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,14 @@
 make-music (4.0.0-0) unstable; urgency=low
 
-  * Applied changes from v3.9.2 es_AR backports to latest
   * Adapted dependency to also build and install on Debian Stretch
 
  -- Team Kano <dev@kano.me>  Thu, 05 Apr 2018 17:40:11 +0100
+
+make-music (3.14.0-0) unstable; urgency=low
+
+  * Applied changes from v3.9.2 es_AR backports to latest
+
+ -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
 
 make-music (3.9.2-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 make-music (3.14.0-0) unstable; urgency=low
 
   * Applied changes from v3.9.2 es_AR backports to latest
+  * Adapted dependency to also build and install on Debian Stretch
 
- -- Team Kano <dev@kano.me>  Mon, 16 Oct 2017 15:12:00 +0100
+ -- Team Kano <dev@kano.me>  Thu, 05 Apr 2018 17:40:11 +0100
 
 make-music (3.9.2-0) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-make-music (3.14.0-0) unstable; urgency=low
+make-music (4.0.0-0) unstable; urgency=low
 
   * Applied changes from v3.9.2 es_AR backports to latest
   * Adapted dependency to also build and install on Debian Stretch

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>=9.0.0), qt4-dev-tools, libqt4-dev, libffi-dev, libqs
 Package: make-music
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, libc6, supercollider, jackd2,
- ruby (>=1.9.3), libqscintilla2-11, libqtgui4, libqt4-network, libqtdbus4,
+ ruby (>=1.9.3), libqscintilla2-11 | libqscintilla2-12v5, libqtgui4, libqt4-network, libqtdbus4,
  kano-toolset (>= 1.2-2), kano-profile (>=2.1-1), libsndfile1, kano-webengine (>= 3.9.0-1)
 Description: Make Music with a music programming environment
  A programatic approach to making music based on Sam Aaron's Sonic Pi


### PR DESCRIPTION
Updated the runtime package dependency to play well on Debian Jessie and Stretch.
The development package for building the software remains the same.
Attaching query below for the records.

```
root@KXBN001:/# cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 9 (stretch)"
NAME="Raspbian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"

root@KXBN001:/# apt-cache search libqscintilla
libqscintilla2-12v5 - Qt4 port of the Scintilla source code editing widget
libqscintilla2-12v5-dbg - Qt4 port of the Scintilla source code editing widget (debug)
libqscintilla2-designer - Qt4 Designer plugin for QScintilla 2
libqscintilla2-designer-dbg - Qt4 Designer plugin for QScintilla 2 (debug)
libqscintilla2-dev - Scintilla source code editing widget for Qt4, development files
libqscintilla2-doc - API documentation for QScintilla 2
libqscintilla2-l10n - Scintilla source code editing widget for Qt4, translation files
libqt5scintilla2-l10n - Scintilla source code editing widget for Qt5, translation files
```
